### PR TITLE
Create User and User Profile route handlers.

### DIFF
--- a/jam_session_back_end/app.js
+++ b/jam_session_back_end/app.js
@@ -9,11 +9,10 @@ app.use(cors());
 const jam_session_routes = require("./routes/jam_sessions_routes");
 const message_routes = require("./routes/message_routes");
 const review_routes = require("./routes/review_routes");
-
 const media_routes = require("./routes/media_routes");
-
 const post_routes = require("./routes/post_routes");
-
+const user_routes = require("./routes/user_routes");
+const profile_routes = require("./routes/user_profile_routes");
 
 app.use(express.static(__dirname + "/public")); // If we have anything that needs to go in a public directory.
 
@@ -24,11 +23,10 @@ app.use(express.static(__dirname + "/public")); // If we have anything that need
 app.use(jam_session_routes);
 app.use(message_routes);
 app.use(review_routes);
-
-
 app.use(media_routes);
-
 app.use(post_routes);
+app.use(user_routes);
+app.use(profile_routes);
 
 app.listen(PORT, function () {
   // This is the basic syntax for what is called the 'listener' which receives incoming requests on the specified PORT.

--- a/jam_session_back_end/controllers/user_controllers.js
+++ b/jam_session_back_end/controllers/user_controllers.js
@@ -1,0 +1,38 @@
+const db = require("./db");
+
+async function getUserById(user_id, res) {
+    const inserts = [user_id];
+    const query = "SELECT * FROM Users WHERE user_id = ?;";
+    await db.pool.query(query, inserts, function (error, results, fields) {
+        return db.returnCallback(error, results, fields, res);
+    });
+}
+
+async function createUser(inserts, res) {
+    const query = "INSERT INTO Users (name, profile_link, email_address) VALUES (?,?,?);";
+    await db.pool.query(query, inserts, function (error, results, fields) {
+        return db.returnCallback(error, results, fields, res);
+    });
+}
+
+async function updateUser(inserts, res) {
+    const query = "UPDATE Users SET name=?, profile_link=?, email_address=? WHERE user_id=?;";
+    await db.pool.query(query, inserts, function (error, results, fields) {
+        return db.returnCallback(error, results, fields, res);
+    });
+}
+
+async function deleteUser(user_id, res) {
+    const inserts = [user_id];
+    const query = "DELETE FROM Users WHERE user_id=?;";
+    await db.pool.query(query, inserts, function (error, results, fields) {
+        return db.returnCallback(error, results, fields, res);
+    });
+}
+
+module.exports = {
+    getUserById,
+    createUser,
+    updateUser,
+    deleteUser,
+};

--- a/jam_session_back_end/controllers/user_profiles_controllers.js
+++ b/jam_session_back_end/controllers/user_profiles_controllers.js
@@ -1,0 +1,39 @@
+const db = require("./db");
+
+async function getUserProfile(user_id, res) {
+    const inserts = [user_id];
+    const query = "SELECT * FROM User_Profile WHERE user_profile_id = ?;";
+    await db.pool.query(query, inserts, function (error, results, fields) {
+        return db.returnCallback(error, results, fields, res);
+    });
+}
+
+async function createUserProfile(inserts, res) {
+    const query =
+        "INSERT INTO User_Profile (user_id, user_photo_link, location, instruments, experience, liked_genres, disliked_genres, portfolio_link, hourly_fee, availability, review_id) VALUES (?,?,?,?,?,?,?,?,?,?,?);";
+    await db.pool.query(query, inserts, function (error, results, fields) {
+        return db.returnCallback(error, results, fields, res);
+    });
+}
+
+async function updateUserProfile(inserts, res) {
+    const query = "UPDATE User_Profile SET user_photo_link=?, location=?, instruments=?, experience=?, liked_genres=?, disliked_genres=?, portfolio_link=?, hourly_fee=?, availability=?, review_id=? WHERE user_id=?;";
+    await db.pool.query(query, inserts, function(error, results, fields) {
+        return db.returnCallback(error, results, fields, res);
+    });
+}
+
+async function deleteUserProfile(user_id, res) {
+    const inserts = [user_id];
+    const query = "DELETE FROM User_Profile WHERE user_id=?;";
+    await db.pool.query(query, inserts, function (error, results, fields) {
+        return db.returnCallback(error, results, fields, res);
+    });
+}
+
+module.exports = {
+    createUserProfile,
+    getUserProfile,
+    updateUserProfile,
+    deleteUserProfile,
+};

--- a/jam_session_back_end/routes/user_profile_routes.js
+++ b/jam_session_back_end/routes/user_profile_routes.js
@@ -1,0 +1,80 @@
+/**
+ * Handles routes for user profiles
+ */
+const express = require("express");
+const router = express.Router();
+const profile_controller = require("../controllers/user_profiles_controllers");
+
+router.use(express.urlencoded({extended: true}));
+
+const path = "/user_profile";
+
+// Create new profile
+router.post(path, async function (req, res) {
+    let inserts = [
+        req.body.user_id,
+        req.body.user_photo_link,
+        req.body.location,
+        req.body.instruments,
+        req.body.experience,
+        req.body.liked_genres,
+        req.body.disliked_genres,
+        req.body.portfolio_link,
+        req.body.hourly_fee,
+        req.body.availability,
+        req.body.review_id
+    ];
+    try {
+        await profile_controller.createUserProfile(inserts, res);
+    } catch (error) {
+        console.log(JSON.stringify(error));
+        res.status(400).send(JSON.stringify(error));
+    }
+})
+
+    // Reads a user profile
+    // Always reference user ID, not user profile ID.
+    .get(`${path}/:id`, async function (req, res) {
+        try {
+            await profile_controller.getUserProfile(req.params.id, res);
+        } catch (error) {
+            console.log(JSON.stringify(error));
+            res.status(404).send(JSON.stringify(error));
+        }
+    })
+
+    // Updates a user profile
+    .put(`${path}/:id`, async function (req, res) {
+        let inserts = [
+            req.body.user_photo_link,
+            req.body.location,
+            req.body.instruments,
+            req.body.experience,
+            req.body.liked_genres,
+            req.body.disliked_genres,
+            req.body.portfolio_link,
+            req.body.hourly_fee,
+            req.body.availability,
+            req.body.review_id,
+            req.params.id
+        ];
+        try {
+            await profile_controller.updateUserProfile(inserts, res);
+        } catch (error) {
+            console.log(JSON.stringify(error));
+            res.status(400).send(JSON.stringify(error));
+        }
+    })
+
+    // Deletes a user profile
+    // Should probably not be used, rely on cascade delete when user is deleted.
+    .delete(`${path}/:id`, async function (req, res) {
+        try {
+            await profile_controller.deleteUserProfile(req.params.id, res);
+        } catch (error) {
+            console.log(JSON.stringify(error));
+            res.status(404).send(JSON.stringify(error));
+        }
+    })
+
+module.exports = router;

--- a/jam_session_back_end/routes/user_routes.js
+++ b/jam_session_back_end/routes/user_routes.js
@@ -1,0 +1,65 @@
+/**
+ * Handles routes for User objects
+ */
+const express = require("express");
+const router = express.Router();
+const user_controller = require("../controllers/user_controllers");
+
+router.use(
+    express.urlencoded({extended: true})
+);
+
+const path = "/user";
+
+// Create new user
+router.post(path, async function (req, res) {
+    let inserts = [
+        req.body.name,
+        req.body.profile_link,
+        req.body.email_address,
+    ];
+    try {
+        await user_controller.createUser(inserts, res);
+    } catch (error) {
+        console.log(JSON.stringify(error));
+        res.status(400).send(JSON.stringify(error));
+    }
+})
+
+    // Reads a User
+    .get(`${path}/:id`, async function (req, res) {
+        try {
+            await user_controller.getUserById(req.params.id, res);
+        } catch (error) {
+            console.log(JSON.stringify(error));
+            res.status(404).send(JSON.stringify(error));
+        }
+    })
+
+    // Updates a User
+    .put(`${path}/:id`, async function (req, res) {
+        let inserts = [
+            req.body.name,
+            req.body.profile_link,
+            req.body.email_address,
+            req.params.id,
+        ];
+        try {
+            await user_controller.updateUser(inserts, res);
+        } catch (error) {
+            console.log(JSON.stringify(error));
+            res.status(400).send(JSON.stringify(error));
+        }
+    })
+
+    // Deletes a User
+    .delete(`${path}/:id`, async function (req, res) {
+        try {
+            await user_controller.deleteUser(req.params.id, res);
+        } catch (error) {
+            console.log(JSON.stringify(error));
+            res.status(404).send(JSON.stringify(error));
+        }
+    })
+
+module.exports = router;


### PR DESCRIPTION
I've built out the API endpoints for Users and User Profiles. Since there's only one profile associated with a user it should always use the user id as the request parameter, not the user_profile_id directly (one less thing for the front end to track.)

I also update the database table to add user_id as a foreign key to the user_profile table - I think in practice we'd want to rely on a cascading delete to take care of the user_profile when/if we delete a user entry.