### PR TITLE
Fix for logout redirect target

### DIFF
--- a/jam_session_front_end/src/Components/Application/Sidebar/Sidebar.js
+++ b/jam_session_front_end/src/Components/Application/Sidebar/Sidebar.js
@@ -113,7 +113,10 @@ function ResponsiveDrawer(props) {
           </ListItemIcon>
           <ListItemText primary="Settings" />
         </ListItem>
-        <ListItem button key="Log Out" onClick={logout}>
+        <ListItem button key="Log Out" onClick={logout({
+          returnTo: "https://main.d4jsy7rjakx88.amplifyapp.com",
+          clientId: process.env.REACT_APP_AUTH0_CLIENT_ID,
+        })}>
           <ListItemIcon>
             <ExitToAppIcon />
           </ListItemIcon>

--- a/jam_session_front_end/src/Components/Authenticate/LogoutButton.js
+++ b/jam_session_front_end/src/Components/Authenticate/LogoutButton.js
@@ -8,7 +8,8 @@ const LogoutButton = ({text}) => {
     const handleLogout = () => {
         logout({
             logoutParams: {
-                returnTo: window.location.origin,
+                returnTo: "https://main.d4jsy7rjakx88.amplifyapp.com",
+                clientId: process.env.REACT_APP_AUTH0_CLIENT_ID,
             },
         });
     };


### PR DESCRIPTION
Updated logout buttons so logout should redirect to landing page rather than localhost:3000.